### PR TITLE
slim python docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # set base image (host OS)
-FROM python:3.8
+FROM jfloff/alpine-python:3.8-slim
 
 # set the working directory in the container
 WORKDIR /code
@@ -7,11 +7,11 @@ WORKDIR /code
 # copy the dependencies file to the working directory
 COPY requirements.txt .
 
-# install dependencies
-RUN pip install -r requirements.txt
-
 # copy the content of the local src directory to the working directory
 COPY main.py .
 
-# command to run on container start
-CMD [ "python", "./main.py" ]
+# -P is part of the base image
+# https://github.com/jfloff/alpine-python/blob/7ae8be3ff086e91051a478ae5fa9acb9f4ec6967/3.8-slim/entrypoint.sh#L23
+# -P: requirements.txt file location (in the container), default is /requirements.txt
+# The base image attempts to pip install dependencies when the container starts using requirements.txt
+CMD [ "-P", "/code/requirements.txt", "python", "./main.py" ]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Spongebobify
-Converts text to Spongebob chicken meme mocking case.
+
+Converts text to Spongebob chicken meme mocking case. On your discord server, invoke using `!spongify Python is a great scripting language`
+
+## Getting Started
+
+The bot needs a token. Someone should write better words on how to generate the token. For now, ask Eric for the token. Once you have a token, you can build the bot from the root of the repo:
+
+```
+docker build -t spongebot .
+```
+
+When running the container, you'll need to inject the token into the container's env. You can, for example, do the following:
+
+```
+docker run -e SPONGE_SECRET={token here} -dt spongebot
+```
+
+If started successfully, the bot should show as online in the Discord server.

--- a/main.py
+++ b/main.py
@@ -43,5 +43,4 @@ else:
     print("No network :( ")
 
 token = os.environ.get("SPONGE_SECRET")
-print(token)
 bot.run(token)


### PR DESCRIPTION
Reduced docker image size using [this base image](https://github.com/jfloff/alpine-python/tree/master/3.8-slim). This base image takes the approach of installing deps at runtime instead of baking them into a layer in the container. This is undesirable, but I don't know enough about python to fix it. I think the tradeoff is worth it because the discord bot is fire and forget. Took the container size from 900mb to 100mb